### PR TITLE
Install packaging package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: be8caaafe3ef2dc2c5ca02d8e91472bbdde0b19df1104170915fbb0b867c17a0
 
 build:
-  number: 3
+  number: 4
   script:
     - {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -25,6 +25,7 @@ requirements:
     - scipy
     - matplotlib-base
     - future
+    - packaging
     - mpich       # [unix]
     - mpi4py      # [unix]
     - pysparse    # [py2k]


### PR DESCRIPTION
`distutils.version.StrictVersion` is deprecated in favor of `packaging.version.Version`.